### PR TITLE
[CI] added support for bumping version of the project using commitizen

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -3,7 +3,7 @@ name: Bump version
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   bump-version:


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/bumpversion.yml` file. The branch name has been updated from `master` to `main` to align with modern naming conventions.